### PR TITLE
Update to gnista 1.0.0

### DIFF
--- a/hammerspace.gemspec
+++ b/hammerspace.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.test_files   = `git ls-files -- spec/*`.split("\n")
   s.require_path = 'lib'
 
-  s.add_runtime_dependency 'gnista', '0.0.5'
+  s.add_runtime_dependency 'gnista', '~> 1.0.0'
 end

--- a/lib/hammerspace/version.rb
+++ b/lib/hammerspace/version.rb
@@ -1,3 +1,3 @@
 module Hammerspace
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
The gnista gem just released an update that fixes another crash issue on OSX. This bumps the dependency for that, in addition to using pessimistic constraints to allow more flexibility. It also bumps the hammerspace version.