### PR TITLE
Avoid an unnecessary call to Gnista::Hash#include? on get

### DIFF
--- a/lib/hammerspace/backend/sparkey.rb
+++ b/lib/hammerspace/backend/sparkey.rb
@@ -49,7 +49,10 @@ module Hammerspace
         close_logwriter
         open_hash
 
-        return @hash[key] if @hash && @hash.include?(key)
+        if @hash
+          value = @hash[key]
+          return value if value
+        end
         frontend.default(key)
       end
 

--- a/spec/features/hash_spec.rb
+++ b/spec/features/hash_spec.rb
@@ -246,6 +246,12 @@ describe Hammerspace do
           hash.close
         end
 
+        it "returns nil if no default is set and key does not exist" do
+          hash = Hammerspace.new(path, options)
+          hash['foo'].should be_nil
+          hash.close
+        end
+
       end
 
       describe "#[]=" do
@@ -257,6 +263,38 @@ describe Hammerspace do
           key = 'key'
           hash['foo'].should == 'bar'
           hash['key'].should be_nil
+          hash.close
+        end
+
+        it "does not allow non-string keys" do
+          hash = Hammerspace.new(path, options)
+          expect {
+            hash[8] = 'foo'
+          }.to raise_error TypeError
+          hash.close
+        end
+
+        it "does not allow non-string values" do
+          hash = Hammerspace.new(path, options)
+          expect {
+            hash['foo'] = 8
+          }.to raise_error TypeError
+          hash.close
+        end
+
+        it "does not allow nil keys" do
+          hash = Hammerspace.new(path, options)
+          expect {
+            hash[nil] = 'foo'
+          }.to raise_error TypeError
+          hash.close
+        end
+
+        it "does not allow nil values" do
+          hash = Hammerspace.new(path, options)
+          expect {
+            hash['foo'] = nil
+          }.to raise_error TypeError
           hash.close
         end
 

--- a/spec/lib/hammerspace/hash_spec.rb
+++ b/spec/lib/hammerspace/hash_spec.rb
@@ -73,8 +73,8 @@ describe Hammerspace::Hash do
     it "unsets default" do
       hash = Hammerspace::Hash.new(path, options)
       hash.default = 'bar'
-      hash.default_proc = p
-      hash.default('foo').should be_nil
+      hash.default_proc = lambda { |h,k| k }
+      hash.default('foo').should == 'foo'
     end
 
   end


### PR DESCRIPTION
Previously we called `include?` to decide whether or not to return the default value instead of just checking the value. This ensures that a stored `false` or `nil` value would not fall back to the default. However, this is unnecessary because `false` and `nil` cannot be stored in Gnista hashes, only strings are allowed and strings are truthy in ruby.

@schleyfox as we discussed this should be safe, but please double-check the specs to see if I'm missing a test case.