### PR TITLE
[Hammerspace] Avoid raising exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.1.6
+* Avoid calling mkdir_p unless needed because it uses exceptions for control flow.
+
 # v0.1.5
 * Avoid an unnecessary call to Gnista::Hash#include? on get.
 

--- a/hammerspace.gemspec
+++ b/hammerspace.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |s|
   s.name         = "hammerspace"
   s.version      = Hammerspace::VERSION
   s.platform     = Gem::Platform::RUBY
-  s.authors      = ["Jon Tai", "Nelson Gauthier"]
-  s.email        = ["jon.tai@airbnb.com", "nelson@airbnb.com"]
+  s.authors      = `git log --format=%an -- lib`.split($/).uniq
+  s.email        = `git log --format=%ae -- lib`.split($/).uniq.grep(/airbnb.com$/)
   s.homepage     = "https://github.com/airbnb/hammerspace"
   s.summary      = "Hash-like interface to persistent, concurrent, off-heap storage"
   s.description  = "A convenient place to store giant hammers"

--- a/lib/hammerspace/backend.rb
+++ b/lib/hammerspace/backend.rb
@@ -63,7 +63,7 @@ module Hammerspace
       protected
 
       def ensure_path_exists(path)
-        FileUtils.mkdir_p(path)
+        FileUtils.mkdir_p(path) unless File.directory?(path)
       end
 
       def lock_for_write

--- a/lib/hammerspace/version.rb
+++ b/lib/hammerspace/version.rb
@@ -1,3 +1,3 @@
 module Hammerspace
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
Avoid calling `mkdir_p` unless needed because it uses exceptions for control flow.

Calling `mkdir_p` raises and rescues a `SystemCallError` if part of the path already exists. See https://github.com/ruby/ruby/blob/trunk/lib/fileutils.rb#L192:L197
```
      ...    
      begin
        fu_mkdir path, mode
        next
      rescue SystemCallError
        next if File.directory?(path)
      end
      ...
```

Also, grab author names from commit history.

Reviewers

- @jtai 
- @nelgau 

Carbon copy

- @jianair 
- @jiayou50
- @liukai 
- @sjagadish