### PR TITLE
Upgrade to gnista 1.0.1

### DIFF
--- a/hammerspace.gemspec
+++ b/hammerspace.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.test_files   = `git ls-files -- spec/*`.split("\n")
   s.require_path = 'lib'
 
-  s.add_runtime_dependency 'gnista', '0.0.5'
+  s.add_runtime_dependency 'gnista', '~> 1.0.1'
 end

--- a/lib/hammerspace/version.rb
+++ b/lib/hammerspace/version.rb
@@ -1,3 +1,3 @@
 module Hammerspace
-  VERSION = '0.1.6'
+  VERSION = '0.1.7'
 end


### PR DESCRIPTION
This brings in the memory leak fix from https://github.com/emnl/gnista/pull/5 and obsoletes #8.

@nelgau 
