### PR TITLE
add :block_size option for compression support

### DIFF
--- a/lib/hammerspace/backend/sparkey.rb
+++ b/lib/hammerspace/backend/sparkey.rb
@@ -168,7 +168,7 @@ module Hammerspace
           # required.
           regenerate_uid
           ensure_path_exists(new_path)
-          logwriter = Gnista::Logwriter.new(new_log_path)
+          logwriter = Gnista::Logwriter.new(*logwriter_args)
           each { |key,value| logwriter[key] = value }
           logwriter
         end
@@ -181,8 +181,12 @@ module Hammerspace
           # locking is required.
           regenerate_uid
           ensure_path_exists(new_path)
-          Gnista::Logwriter.new(new_log_path)
+          Gnista::Logwriter.new(*logwriter_args)
         end
+      end
+
+      def logwriter_args
+        [new_log_path, options[:block_size]].compact
       end
 
       def close_logwriter

--- a/spec/lib/hammerspace/backend/sparkey_spec.rb
+++ b/spec/lib/hammerspace/backend/sparkey_spec.rb
@@ -21,6 +21,32 @@ describe Hammerspace::Backend::Sparkey do
     Dir.exist?(path).should be_true
   end
 
+  describe "compression with :block_size option" do
+    def total
+      Dir.glob("#{path}/**/*")
+        .select(&File.method(:file?))
+        .map(&File.method(:size))
+        .inject(:+)
+    end
+
+    def fill_hash(hash)
+      1000.times do |n|
+        hash["foo#{n}"] = 'bar' * 100
+      end
+      hash.close
+    end
+
+    it "does not compress without :block_size option" do
+      fill_hash(Hammerspace.new(path, options))
+      total.should == 319_494
+    end
+
+    it "compresses with :block_size option" do
+      fill_hash(Hammerspace.new(path, options.merge(block_size: 4096)))
+      total.should == 29_252
+    end
+  end
+
   it "bulks writes" do
     Gnista::Hash.should_receive(:write).once.and_call_original
 


### PR DESCRIPTION
Since Sparkey requires Snappy anyway, might as well expose the API to take advantage of the compression it offers. This PR adds a `:block_size` option passed down to Sparkey which adds block-level Snappy compression to the storage file when provided.